### PR TITLE
Renamed and removed

### DIFF
--- a/cli/src/main/scala/jdksymlink/cli/JdkSymLinkApp.scala
+++ b/cli/src/main/scala/jdksymlink/cli/JdkSymLinkApp.scala
@@ -17,7 +17,7 @@ import jdksymlink.info.JdkSymLinkBuildInfo
  * @author Kevin Lee
  * @since 2019-12-24
  */
-object JdkSymLinkApp extends MainIO[JdkSymLinkArgs] {
+object JdkSymLinkApp extends MainIo[JdkSymLinkArgs] {
 
   val listParser: Parse[JdkSymLinkArgs] = ValueParse(JdkSymLinkArgs.jdkListArgs)
 

--- a/cli/src/main/scala/jdksymlink/cli/MainIo.scala
+++ b/cli/src/main/scala/jdksymlink/cli/MainIo.scala
@@ -14,9 +14,7 @@ import scalaz._
  * @author Kevin Lee
  * @since 2019-12-09
  */
-trait MainIO[A] {
-
-  type SIO[X] = scalaz.effect.IO[X]
+trait MainIo[A] {
 
   def command: Command[A]
  


### PR DESCRIPTION
* Renamed: `MainIO` => `MainIo`
* Removed: Unnecessary type alias, `SIO`