### PR TITLE
jdk-sym-link v0.1.0

### DIFF
--- a/changelogs/0.1.0.md
+++ b/changelogs/0.1.0.md
@@ -1,0 +1,11 @@
+## [0.1.0](https://github.com/Kevin-Lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone1) - 2021-02-22
+
+## Done
+* Import `jdk-ln-s` from my gist (#12)
+* Add proper CLI (#13)
+* Make cli use core (#20)
+* Use tagless-final (#25)
+* Remove `JdkSymLinkBridge` (#28)
+* Make `JdkSymLink` referentially transparent (#33)
+* Add proper errors (#23)
+* Add installation script (#61)


### PR DESCRIPTION
# jdk-sym-link v0.1.0
## [0.1.0](https://github.com/Kevin-Lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone1) - 2021-02-22

## Done
* Import `jdk-ln-s` from my gist (#12)
* Add proper CLI (#13)
* Make cli use core (#20)
* Use tagless-final (#25)
* Remove `JdkSymLinkBridge` (#28)
* Make `JdkSymLink` referentially transparent (#33)
* Add proper errors (#23)
* Add installation script (#61)
