### PR TITLE
jdk-sym-link v0.2.0

### DIFF
--- a/.scripts/install.sh
+++ b/.scripts/install.sh
@@ -5,7 +5,7 @@ set -eu
 app_original_executable_name=jdk-sym-link
 app_executable_name=jdkslink
 app_name=jdk-sym-link-cli
-app_version=${1:-0.1.0}
+app_version=${1:-0.2.0}
 versioned_app_name="${app_name}-${app_version}"
 app_zip_file="${versioned_app_name}.zip"
 download_url="https://github.com/Kevin-Lee/jdk-sym-link/releases/download/v${app_version}/${app_zip_file}"

--- a/changelogs/0.2.0.md
+++ b/changelogs/0.2.0.md
@@ -1,0 +1,5 @@
+## [0.2.0](https://github.com/Kevin-Lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone2) - 2021-02-25
+
+## Done
+* Remove unnecessary java version param name (#66)
+* Better way to handle console color (#68)

--- a/project/SbtProjectInfo.scala
+++ b/project/SbtProjectInfo.scala
@@ -2,6 +2,6 @@
 object SbtProjectInfo {
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "0.1.0"
+  val ProjectVersion: String = "0.2.0"
 
 }


### PR DESCRIPTION
# jdk-sym-link v0.2.0
## [0.2.0](https://github.com/Kevin-Lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone2) - 2021-02-25

## Done
* Remove unnecessary java version param name (#66)
* Better way to handle console color (#68)
