### PR TITLE
jdk-sym-link v0.2.1

### DIFF
--- a/changelogs/0.2.1.md
+++ b/changelogs/0.2.1.md
@@ -1,0 +1,18 @@
+## [0.2.1](https://github.com/Kevin-Lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone3) - 2021-02-27
+
+## Fixed
+* Error message contains irrelevant words (i.e. `Reset`) (#71)
+  
+  e.g.)
+  Before
+  ```
+  ErrorCodeReset: 1
+  ErrorReset: sudo: 3 incorrect password attempts
+    when running [sudo, rm, jdk8]
+  ```
+  Now
+  ```
+  ErrorCode: 1
+  Error: sudo: 3 incorrect password attempts
+    when running [sudo, rm, jdk8]
+  ```

--- a/project/SbtProjectInfo.scala
+++ b/project/SbtProjectInfo.scala
@@ -2,6 +2,6 @@
 object SbtProjectInfo {
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "0.2.0"
+  val ProjectVersion: String = "0.2.1"
 
 }


### PR DESCRIPTION
# jdk-sym-link v0.2.1
## [0.2.1](https://github.com/Kevin-Lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone3) - 2021-02-27

## Fixed
* Error message contains irrelevant words (i.e. `Reset`) (#71)
  
  e.g.)
  Before
  ```
  ErrorCodeReset: 1
  ErrorReset: sudo: 3 incorrect password attempts
    when running [sudo, rm, jdk8]
  ```
  Now
  ```
  ErrorCode: 1
  Error: sudo: 3 incorrect password attempts
    when running [sudo, rm, jdk8]
  ```
