### PR TITLE
jdk-sym-link v0.3.0

### DIFF
--- a/changelogs/0.3.0.md
+++ b/changelogs/0.3.0.md
@@ -1,0 +1,10 @@
+## [0.3.0](https://github.com/Kevin-Lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone4) - 2021-05-08
+
+## Done
+* Use Scala `3.0.0-RC1` (#75)
+* Build with GraalVM (#81)
+* Update installation script to install the GraalVM Native Image version of `jdk-sym-link` (#84)
+* Upgrade Scala to `3.0.0-RC3` (#90)
+* Use more Scala 3 only features (#92)
+* Make error message more readable (#96)
+* Use `enum`'s data constructor and more `extension` methods (#98)

--- a/project/SbtProjectInfo.scala
+++ b/project/SbtProjectInfo.scala
@@ -2,6 +2,6 @@
 object SbtProjectInfo {
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "0.2.1"
+  val ProjectVersion: String = "0.3.0"
 
 }


### PR DESCRIPTION
# jdk-sym-link v0.3.0
## [0.3.0](https://github.com/Kevin-Lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone4) - 2021-05-08

## Done
* Use Scala `3.0.0-RC1` (#75)
* Build with GraalVM (#81)
* Update installation script to install the GraalVM Native Image version of `jdk-sym-link` (#84)
* Upgrade Scala to `3.0.0-RC3` (#90)
* Use more Scala 3 only features (#92)
* Make error message more readable (#96)
* Use `enum`'s data constructor and more `extension` methods (#98)
