### PR TITLE
Added: Typeclass CanEqual instance for CanEqual[Option[T], Option[U]]

### DIFF
--- a/core/src/main/scala/jdksymlink/core/data.scala
+++ b/core/src/main/scala/jdksymlink/core/data.scala
@@ -13,6 +13,7 @@ import scala.util.matching.Regex
 object data {
   type Eql[A] = CanEqual[A, A]
   given optionEql[A](using CanEqual[A, A]): Eql[Option[A]] = CanEqual.derived
+  given canEqualOption[T, U](using eq: CanEqual[T, U]): CanEqual[Option[T], Option[U]] = CanEqual.derived
 
   final val JavaBaseDirPath: String = "/Library/Java/JavaVirtualMachines"
   lazy val javaBaseDirFile: File = new File(JavaBaseDirPath)


### PR DESCRIPTION
Added: Typeclass `CanEqual` instance for `CanEqual[Option[T], Option[U]]`