### PR TITLE
jdk-sym-link v0.5.0

### DIFF
--- a/changelogs/0.5.0.md
+++ b/changelogs/0.5.0.md
@@ -1,0 +1,6 @@
+## [0.5.0](https://github.com/Kevin-Lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone6) - 2021-09-27
+
+## Done
+* Move `CanEqual` typeclass instances to instances package (#110)
+* Replace `CanEqual` instances with `can-equal` (#113)
+* Support JDK installed by Coursier (#119)

--- a/project/SbtProjectInfo.scala
+++ b/project/SbtProjectInfo.scala
@@ -2,6 +2,6 @@
 object SbtProjectInfo {
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "0.4.0"
+  val ProjectVersion: String = "0.5.0"
 
 }


### PR DESCRIPTION
# jdk-sym-link v0.5.0
## [0.5.0](https://github.com/Kevin-Lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone6) - 2021-09-27

## Done
* Move `CanEqual` typeclass instances to instances package (#110)
* Replace `CanEqual` instances with `can-equal` (#113)
* Support JDK installed by Coursier (#119)
