### PR TITLE
jdk-sym-link v0.5.1

### DIFF
--- a/.scripts/install.sh
+++ b/.scripts/install.sh
@@ -5,7 +5,7 @@ set -eu
 app_original_executable_name=jdk-sym-link
 app_executable_name=jdkslink
 app_name=jdk-sym-link-cli
-app_version=${1:-0.5.0}
+app_version=${1:-0.5.1}
 app_package_file="${app_name}"
 download_url="https://github.com/Kevin-Lee/jdk-sym-link/releases/download/v${app_version}/${app_package_file}"
 

--- a/changelogs/0.5.1.md
+++ b/changelogs/0.5.1.md
@@ -1,0 +1,5 @@
+## [0.5.1](https://github.com/Kevin-Lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone7) - 2021-09-27
+
+## Fixed
+* User home directory is not retrieved in runtime (#126)
+* Error when Coursier jvm directory doesn't exist (#127)

--- a/project/SbtProjectInfo.scala
+++ b/project/SbtProjectInfo.scala
@@ -2,6 +2,6 @@
 object SbtProjectInfo {
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "0.5.0"
+  val ProjectVersion: String = "0.5.1"
 
 }


### PR DESCRIPTION
# jdk-sym-link v0.5.1
## [0.5.1](https://github.com/Kevin-Lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone7) - 2021-09-27

## Fixed
* User home directory is not retrieved in runtime (#126)
* Error when Coursier jvm directory doesn't exist (#127)
