### PR TITLE
jdk-sym-link v0.5.2

### DIFF
--- a/changelogs/0.5.2.md
+++ b/changelogs/0.5.2.md
@@ -1,0 +1,4 @@
+## [0.5.2](https://github.com/Kevin-Lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone8) - 2021-09-28
+
+## Fixed
+* Error when there's no file in the JDK directories (#133)

--- a/project/SbtProjectInfo.scala
+++ b/project/SbtProjectInfo.scala
@@ -2,6 +2,6 @@
 object SbtProjectInfo {
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "0.5.1"
+  val ProjectVersion: String = "0.5.2"
 
 }


### PR DESCRIPTION
# jdk-sym-link v0.5.2
## [0.5.2](https://github.com/Kevin-Lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone8) - 2021-09-28

## Fixed
* Error when there's no file in the JDK directories (#133)
