### PR TITLE
jdk-sym-link v0.6.0

### DIFF
--- a/changelogs/0.6.0.md
+++ b/changelogs/0.6.0.md
@@ -1,0 +1,4 @@
+## [0.6.0](https://github.com/Kevin-Lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone9) - 2021-10-15
+
+## Done
+* Upgrade `can-equal` (#139)

--- a/project/SbtProjectInfo.scala
+++ b/project/SbtProjectInfo.scala
@@ -2,6 +2,6 @@
 object SbtProjectInfo {
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "0.5.2"
+  val ProjectVersion: String = "0.6.0"
 
 }


### PR DESCRIPTION
# jdk-sym-link v0.6.0
## [0.6.0](https://github.com/Kevin-Lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone9) - 2021-10-15

## Done
* Upgrade `can-equal` (#139)
