### PR TITLE
Close #159 - Upgrade Scala and libraries (`cats-effect`, `effectie`, etc.)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,10 @@ lazy val core = projectCommonSettings("core", ProjectName("core"), file("core"))
   .enablePlugins(BuildInfoPlugin)
   .settings(
     libraryDependencies ++=
-      List(libs.justSysProcess) ++ libs.catsAndCatsEffect ++ libs.effectie ++ List(libs.extrasCats)
+      List(libs.justSysProcess) ++
+        libs.catsAndCatsEffect ++
+        libs.effectie ++
+        List(libs.extrasCats, libs.extrasScalaIo)
     /* Build Info { */,
     buildInfoKeys    := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoObject  := "JdkSymLinkBuildInfo",
@@ -47,7 +50,7 @@ lazy val cli = projectCommonSettings("cli", ProjectName("cli"), file("cli"))
       "--initialize-at-build-time",
 //      s"-H:ReflectionConfigurationFiles=${ (sourceDirectory.value / "graal" / "reflect-config.json").getCanonicalPath }",
 //      "--allow-incomplete-classpath",
-//      "--report-unsupported-elements-at-runtime",
+      "--report-unsupported-elements-at-runtime",
     ),
   )
   .dependsOn(core, pirate)
@@ -73,19 +76,17 @@ lazy val props =
     final val RepoName            = "jdk-sym-link"
     final val ProjectNamePrefix   = RepoName
     final val ProjectVersion      = SbtProjectInfo.ProjectVersion
-    final val ProjectScalaVersion = "3.1.0"
+    final val ProjectScalaVersion = "3.1.2"
 
-    final val canEqualVersion = "0.1.1"
+    final val effectieVersion = "2.0.0-beta1"
+    final val refinedVersion  = "0.9.27"
 
-    final val effectieVersion = "1.15.0"
-    final val refinedVersion  = "0.9.25"
+    final val catsVersion       = "2.7.0"
+    final val catsEffectVersion = "3.3.12"
 
-    final val catsVersion       = "2.6.1"
-    final val catsEffectVersion = "2.5.4"
+    final val ExtrasVersion = "0.14.0"
 
-    final val ExtrasVersion = "0.1.0"
-
-    final val hedgehogVersion = "0.7.0"
+    final val hedgehogVersion = "0.9.0"
 
     final val justSysprocessVersion = "1.0.0"
 
@@ -107,8 +108,6 @@ lazy val libs =
 
     lazy val justSysProcess = "io.kevinlee" %% "just-sysprocess" % props.justSysprocessVersion
 
-    lazy val canEqual = "io.kevinlee" %% "can-equal" % props.canEqualVersion
-
     lazy val refined = List(
       "eu.timepit" %% "refined" % props.refinedVersion
     )
@@ -119,11 +118,12 @@ lazy val libs =
     )
 
     lazy val effectie = List(
-      "io.kevinlee" %% "effectie-cats-effect"   % props.effectieVersion,
-      "io.kevinlee" %% "effectie-scalaz-effect" % props.effectieVersion,
+      "io.kevinlee" %% "effectie-cats-effect3" % props.effectieVersion,
+//      "io.kevinlee" %% "effectie-scalaz-effect" % props.effectieVersion,
     )
 
-    lazy val extrasCats = "io.kevinlee" %% "extras-cats" % props.ExtrasVersion
+    lazy val extrasCats    = "io.kevinlee" %% "extras-cats"     % props.ExtrasVersion
+    lazy val extrasScalaIo = "io.kevinlee" %% "extras-scala-io" % props.ExtrasVersion
 
   }
 
@@ -135,7 +135,7 @@ else
 def projectCommonSettings(id: String, projectName: ProjectName, file: File): Project =
   Project(id, file)
     .settings(
-      name := prefixedProjectName(projectName.projectName),
+      name                       := prefixedProjectName(projectName.projectName),
       useAggressiveScalacOptions := true,
       libraryDependencies ++= libs.hedgehogLibs ++ libs.refined,
       testFrameworks ++= Seq(TestFramework("hedgehog.sbt.Framework")),

--- a/cli/src/main/scala/jdksymlink/cli/JdkSymLinkApp.scala
+++ b/cli/src/main/scala/jdksymlink/cli/JdkSymLinkApp.scala
@@ -2,82 +2,33 @@ package jdksymlink.cli
 
 import pirate.*
 import Pirate.*
-import piratex.*
 import cats.data.*
 import cats.effect.*
 import cats.syntax.all.*
-import jdksymlink.core.{JdkSymLink, JdkSymLinkError, Utils}
+import effectie.cats.fx.ioFx
+import extras.cats.syntax.all.*
 import jdksymlink.core.data.{Coursier, DefaultJdk, JavaMajorVersion}
+import jdksymlink.core.{JdkSymLink, JdkSymLinkError, Utils}
 import jdksymlink.info.JdkSymLinkBuildInfo
+import piratex.*
 
 /** @author Kevin Lee
   * @since 2019-12-24
   */
 object JdkSymLinkApp extends MainIo[JdkSymLinkArgs] {
 
-  val listParser: Parse[JdkSymLinkArgs] = ValueParse(JdkSymLinkArgs.JdkListArgs)
-
-  val symLinkJdkParser: Parse[JdkSymLinkArgs] = {
-    import scalaz.*
-    import Scalaz.*
-    JdkSymLinkArgs.SymLinkArgs.apply |*|
-      argument[Int](
-        metavar("<java-version>") |+| description("Java version e.g.) 8, 11, 16")
-      ).map(JavaMajorVersion.apply)
-  }
-
-  val rawCmd: Command[JdkSymLinkArgs] = {
-    import scalaz.*
-    import Scalaz.*
-    Command(
-      "jdk-sym-link",
-      "JDK symbolic link creator".some,
-      (subcommand(
-        Command(
-          "list",
-          "List all JDKs".some,
-          listParser
-        )
-      ) ||| subcommand(
-        Command(
-          "slink",
-          "Create JDK symbolic link".some,
-          symLinkJdkParser
-        )
-      )) <* version(JdkSymLinkBuildInfo.version)
-    )
-  }
-
   val cmd: Command[JdkSymLinkArgs] =
     Metavar.rewriteCommand(
-      Help.rewriteCommand(rawCmd)
+      Help.rewriteCommand(JdkSymLinkArgs.rawCmd),
     )
 
   override def command: Command[JdkSymLinkArgs] = cmd
 
-  override def run(args: JdkSymLinkArgs): IO[Either[NonEmptyList[JdkSymLinkError], Unit]] =
-    args match {
-      case JdkSymLinkArgs.JdkListArgs =>
-        for {
-          jdk      <- JdkSymLink[IO]
-                        .listAll(DefaultJdk.JavaBaseDirPath, DefaultJdk.javaBaseDirFile)
-          coursier <- JdkSymLink[IO]
-                        .listAll(Coursier.CoursierJavaBaseDirPath, Coursier.coursierJavaBaseDirFile)
-        } yield (jdk.toValidatedNel, coursier.toValidatedNel)
-          .mapN((_, _) => ())
-          .toEither
+  override def prefs: Prefs = DefaultPrefs().copy(width = 100)
 
-      case JdkSymLinkArgs.SymLinkArgs(javaVersion) =>
-        JdkSymLink[IO]
-          .slink(
-            javaVersion,
-            NonEmptyList.of(
-              (DefaultJdk.JavaBaseDirPath, Utils.extractVersion),
-              (Coursier.CoursierJavaBaseDirPath, Utils.extractCoursierJavaVersion)
-            ),
-            DefaultJdk.javaBaseDirFile
-          )
-          .map(_.leftMap(NonEmptyList.one(_)))
-    }
+  override def runApp(args: JdkSymLinkArgs): IO[Either[JdkSymLinkAppError, Option[String]]] =
+    JdkSymLinkRun[IO](args)
+      .map(_.map(_ => none[String]))
+
 
 }

--- a/cli/src/main/scala/jdksymlink/cli/JdkSymLinkAppError.scala
+++ b/cli/src/main/scala/jdksymlink/cli/JdkSymLinkAppError.scala
@@ -1,0 +1,33 @@
+package jdksymlink.cli
+
+import cats.data.NonEmptyList
+import cats.syntax.all.*
+import extras.scala.io.syntax.color.*
+import jdksymlink.cli.JdkSymLinkArgs.ArgParseError
+import jdksymlink.core.JdkSymLinkError
+
+/** @author Kevin Lee
+  * @since 2022-06-02
+  */
+enum JdkSymLinkAppError {
+  case JdkSymLinkCore(jdkSymLinkError: JdkSymLinkError)
+  case MultipleJdkSymLinkCore(jdkSymLinkErrors: NonEmptyList[JdkSymLinkError])
+  case ArgParse(argParseError: ArgParseError)
+}
+
+object JdkSymLinkAppError {
+  extension (jdkSymLinkAppError: JdkSymLinkAppError) {
+    def render: String = jdkSymLinkAppError match {
+      case JdkSymLinkAppError.JdkSymLinkCore(err) =>
+        err.render
+
+      case JdkSymLinkAppError.MultipleJdkSymLinkCore(jdkSymLinkErrors) =>
+        jdkSymLinkErrors.map(_.render).toList.mkString("\n")
+
+      case JdkSymLinkAppError.ArgParse(err) =>
+        s"""${"CLI arguments error".red}:
+           |${err.show}
+           |""".stripMargin
+    }
+  }
+}

--- a/cli/src/main/scala/jdksymlink/cli/JdkSymLinkArgs.scala
+++ b/cli/src/main/scala/jdksymlink/cli/JdkSymLinkArgs.scala
@@ -1,6 +1,10 @@
 package jdksymlink.cli
 
+import cats.Show
 import jdksymlink.core.data.JavaMajorVersion
+import jdksymlink.info.JdkSymLinkBuildInfo
+import pirate.*
+import Pirate.*
 
 /** @author Kevin Lee
   * @since 2019-12-24
@@ -9,5 +13,55 @@ enum JdkSymLinkArgs derives CanEqual {
 
   case JdkListArgs
   case SymLinkArgs(javaMajorVersion: JavaMajorVersion)
+
+}
+
+object JdkSymLinkArgs {
+
+
+  val listParser: Parse[JdkSymLinkArgs] = ValueParse(JdkSymLinkArgs.JdkListArgs)
+
+  val symLinkJdkParser: Parse[JdkSymLinkArgs] = {
+    import scalaz.*
+    import Scalaz.*
+    JdkSymLinkArgs.SymLinkArgs.apply |*|
+      argument[Int](
+        metavar("<java-version>") |+| description("Java version e.g.) 8, 11, 17")
+      ).map(JavaMajorVersion.apply)
+  }
+
+  val rawCmd: Command[JdkSymLinkArgs] = {
+    import scalaz.*
+    import Scalaz.*
+    Command(
+      "jdk-sym-link",
+      "JDK symbolic link creator".some,
+      (subcommand(
+        Command(
+          "list",
+          "List all JDKs".some,
+          listParser
+        )
+      ) ||| subcommand(
+        Command(
+          "slink",
+          "Create JDK symbolic link".some,
+          symLinkJdkParser
+        )
+      )) <* version(JdkSymLinkBuildInfo.version)
+    )
+  }
+
+  final case class JustMessageOrHelp(messages: List[String])
+  object JustMessageOrHelp {
+    given show: Show[JustMessageOrHelp] = _.messages.mkString("\n")
+  }
+  final case class ArgParseError(errors: List[String])
+  object ArgParseError {
+    given show: Show[ArgParseError] = _.errors.mkString("\n")
+  }
+
+  type ArgParseFailureResult =
+    JustMessageOrHelp | ArgParseError
 
 }

--- a/cli/src/main/scala/jdksymlink/cli/JdkSymLinkRun.scala
+++ b/cli/src/main/scala/jdksymlink/cli/JdkSymLinkRun.scala
@@ -1,0 +1,44 @@
+package jdksymlink.cli
+
+import cats.*
+import cats.syntax.all.*
+import cats.data.NonEmptyList
+import cats.effect.IO
+import effectie.core.Fx
+import jdksymlink.core.data.{Coursier, DefaultJdk}
+import jdksymlink.core.{JdkSymLink, Utils}
+import extras.cats.syntax.all.*
+
+/**
+ * @author Kevin Lee
+ * @since 2022-06-02
+ */
+object JdkSymLinkRun {
+  def apply[F[_]: Fx: Monad](args: JdkSymLinkArgs): F[Either[JdkSymLinkAppError, Unit]] =
+    args match {
+      case JdkSymLinkArgs.JdkListArgs =>
+        for {
+          jdk      <- JdkSymLink[F]
+            .listAll(DefaultJdk.JavaBaseDirPath, DefaultJdk.javaBaseDirFile)
+          coursier <- JdkSymLink[F]
+            .listAll(Coursier.CoursierJavaBaseDirPath, Coursier.coursierJavaBaseDirFile)
+        } yield (jdk.toValidatedNel, coursier.toValidatedNel)
+          .mapN((_, _) => ())
+          .toEither
+          .leftMap(JdkSymLinkAppError.MultipleJdkSymLinkCore(_))
+
+      case JdkSymLinkArgs.SymLinkArgs(javaVersion) =>
+        JdkSymLink[F]
+          .slink(
+            javaVersion,
+            NonEmptyList.of(
+              (DefaultJdk.JavaBaseDirPath, Utils.extractVersion),
+              (Coursier.CoursierJavaBaseDirPath, Utils.extractCoursierJavaVersion)
+            ),
+            DefaultJdk.javaBaseDirFile
+          )
+          .t
+          .leftMap(JdkSymLinkAppError.JdkSymLinkCore(_))
+          .value
+    }
+}

--- a/cli/src/main/scala/jdksymlink/cli/MainIo.scala
+++ b/cli/src/main/scala/jdksymlink/cli/MainIo.scala
@@ -1,52 +1,72 @@
 package jdksymlink.cli
 
-import cats.effect.*
 import cats.data.NonEmptyList
+import cats.effect.{ExitCode, *}
 import cats.syntax.all.*
-import effectie.cats.ConsoleEffect
+import effectie.cats.console.given
+import effectie.cats.fx.ioFx
+import effectie.core.ConsoleEffect
+import effectie.syntax.all.*
+import jdksymlink.cli.JdkSymLinkArgs.{ArgParseError, ArgParseFailureResult, JustMessageOrHelp}
 import jdksymlink.core.JdkSymLinkError
 import pirate.{ExitCode as PirateExitCode, *}
-import scalaz.*
 
 import scala.io.AnsiColor
 
 /** @author Kevin Lee
   * @since 2019-12-09
   */
-trait MainIo[A] {
+trait MainIo[A] extends IOApp {
 
-  def command: Command[A]
+  protected def command: Command[A]
 
-  def run(a: A): IO[Either[NonEmptyList[JdkSymLinkError], Unit]]
-  private def run0(a: A): IO[NonEmptyList[JdkSymLinkError] \/ Unit] =
-    run(a).map(\/.fromEither(_))
+  protected def runApp(a: A): IO[Either[JdkSymLinkAppError, Option[String]]]
 
-  def prefs: Prefs = DefaultPrefs()
+  protected def prefs: Prefs
 
-  def exitWith[X](exitCode: ExitCode): IO[X] =
-    IO(sys.exit(exitCode.code))
+  private def exitCodeToEither(argParseFailureResult: ArgParseFailureResult): IO[Either[JdkSymLinkAppError, Option[String]]] =
+    argParseFailureResult match {
+      case err @ JustMessageOrHelp(_) =>
+        IO.pure(err.show.some.asRight[JdkSymLinkAppError])
+      case err @ ArgParseError(_)     =>
+        IO(JdkSymLinkAppError.ArgParse(err).asLeft[Option[String]])
+    }
 
-  def exitWithPirate[X](exitCode: PirateExitCode): IO[X] =
-    IO(exitCode.fold(sys.exit(0), sys.exit(_)))
-
-  def getArgs(args: Array[String], command: Command[A], prefs: Prefs): IO[PirateExitCode \/ A] =
-    IO(Runners.runWithExit[A](args.toList, command, prefs).unsafePerformIO())
-
-  def main(args: Array[String]): Unit = (for {
-    codeOrA       <- getArgs(args, command, prefs)
-    errorOrResult <- codeOrA.fold[IO[NonEmptyList[JdkSymLinkError] \/ Unit]](exitWithPirate, run0)
-    _             <- errorOrResult.fold(
-                       errs =>
-                         ConsoleEffect[IO].putStrLn(
-                           errs
-                             .map(_.render)
-                             .toList
-                             .mkString(s"${AnsiColor.RED}Error:${AnsiColor.RESET}\n- ", "\n- ", "\n")
-                         ) >>
-                           exitWith(ExitCode.Error),
-                       IO(_)
-                     )
-  } yield ())
-    .unsafeRunSync()
+  override def run(args: List[String]): IO[ExitCode] = {
+    def getArgs(
+      args: List[String],
+      command: Command[A],
+      prefs: Prefs,
+    ): IO[Either[ArgParseFailureResult, A]] = {
+      import pirate.{Interpreter, Usage}
+      import scalaz.{-\/, \/-}
+      Interpreter.run(command.parse, args, prefs) match {
+        case (ctx, -\/(e)) =>
+          IO(
+            Usage
+              .printError(command, ctx, e, prefs)
+              .fold[ArgParseFailureResult](
+                ArgParseError(_),
+                JustMessageOrHelp(_),
+              )
+              .asLeft[A],
+          )
+        case (_, \/-(v))   =>
+          IO(v.asRight[ArgParseFailureResult])
+      }
+    }
+    for {
+      codeOrA       <- getArgs(args, command, prefs)
+      errorOrResult <- codeOrA.fold(exitCodeToEither, runApp)
+      code          <- errorOrResult.fold(
+                         err =>
+                           putErrStrLn[IO](err.render) >>
+                             IO(ExitCode.Error),
+                         _.fold(
+                           IO(ExitCode.Success),
+                         )(msg => putStrLn[IO](msg) >> IO(ExitCode.Success)),
+                       )
+    } yield code
+  }
 
 }

--- a/core/src/main/scala/jdksymlink/core/JdkSymLink.scala
+++ b/core/src/main/scala/jdksymlink/core/JdkSymLink.scala
@@ -4,11 +4,11 @@ import Utils.*
 import cats.*
 import cats.data.*
 import cats.syntax.all.*
-import effectie.YesNo
-import effectie.cats.ConsoleEffectful.*
-import effectie.cats.Effectful.*
-import extras.cats.syntax.either.*
-import effectie.cats.{ConsoleEffect, EffectConstructor}
+import effectie.cats.console.given
+import effectie.cats.syntax.all.*
+import effectie.core.{Fx, YesNo}
+import effectie.syntax.all.*
+import extras.cats.syntax.all.*
 import jdksymlink.core.data.*
 import just.sysprocess.*
 
@@ -43,12 +43,12 @@ object JdkSymLink {
 
   def apply[F[_]: JdkSymLink]: JdkSymLink[F] = summon[JdkSymLink[F]]
 
-  given jdkSymLinkF[F[_]: Monad: EffectConstructor: ConsoleEffect]: JdkSymLink[F] with {
+  given jdkSymLinkF[F[_]: Monad: Fx]: JdkSymLink[F] with {
 
     def listAll(javaBaseDirPath: JvmBaseDirPath, javaBaseDir: File): F[Either[JdkSymLinkError, Unit]] =
       (for {
         dirNotExists <- effectOf(!javaBaseDirPath.toPath.dirExist).rightT
-        _            <- if (dirNotExists) then putStrLn(s"${javaBaseDirPath.value} does not exist.").rightT
+        _            <- if dirNotExists then putStrLn(s"${javaBaseDirPath.value} does not exist.").rightT
                         else
                           for {
                             _ <- putStrLn(

--- a/core/src/main/scala/jdksymlink/core/JdkSymLinkError.scala
+++ b/core/src/main/scala/jdksymlink/core/JdkSymLinkError.scala
@@ -12,7 +12,7 @@ enum JdkSymLinkError derives CanEqual {
   case LsFailure(errorCode: Int, message: String, commands: List[String])
   case PathExistsAndNoSymLink(path: String, message: String, commands: List[String])
   case CommandFailure(throwable: Throwable, commands: List[String])
-
+//  case ArgParse(argError: ArgParseError)
 }
 
 object JdkSymLinkError {


### PR DESCRIPTION
Close #159 - Upgrade Scala and libraries (`cats-effect`, `effectie`, etc.)
- `effectie` `1.15.0` => `2.0.0-beta1`
- Scala `3.1.0` => `3.1.2`
- Remove `can-equal`
- `refined` `0.9.25` => `0.9.27`
- `cats` `2.6.1` => `2.7.0`
- `cats-effect` `2.5.4` => `3.3.12`
- `extras` `0.1.0` => `0.14.0`