### PR TITLE
jdk-sym-link v0.9.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -121,7 +121,6 @@ lazy val libs =
 
     lazy val effectie = List(
       "io.kevinlee" %% "effectie-cats-effect3" % props.effectieVersion,
-//      "io.kevinlee" %% "effectie-scalaz-effect" % props.effectieVersion,
     )
 
     lazy val extrasCats    = "io.kevinlee" %% "extras-cats"     % props.ExtrasVersion

--- a/changelogs/0.9.0.md
+++ b/changelogs/0.9.0.md
@@ -1,0 +1,16 @@
+## [0.9.0](https://github.com/Kevin-Lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone12) - 2022-06-13
+
+## Done
+* Upgrade Scala and libraries (`cats-effect`, `effectie`, etc.) (#159)
+  * `effectie` `1.15.0` => `2.0.0-beta1` - `effectie-cats-effect` => `effectie-cats-effect3`
+  * Remove `effectie-scalaz-effect`
+  * Scala `3.1.0` => `3.1.2`
+  * Remove `can-equal`
+  * `refined` `0.9.25` => `0.9.29`
+  * `cats` `2.6.1` => `2.7.0`
+  * `cats-effect` `2.5.4` => `3.3.12`
+  * `extras` `0.1.0` => `0.15.0`
+  * Add `just-semver` `0.5.0`
+  * Add `extras-scala-io` `0.15.0`
+* List JDK paths from Coursier (`cs java --installed`) (#166)
+* Symlink to JDKs from Coursier (`cs java --installed`) (#167)

--- a/project/SbtProjectInfo.scala
+++ b/project/SbtProjectInfo.scala
@@ -1,6 +1,6 @@
 object SbtProjectInfo {
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "0.8.0"
+  val ProjectVersion: String = "0.9.0"
 
 }


### PR DESCRIPTION
# jdk-sym-link v0.9.0
## [0.9.0](https://github.com/Kevin-Lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone12) - 2022-06-13

## Done
* Upgrade Scala and libraries (`cats-effect`, `effectie`, etc.) (#159)
  * `effectie` `1.15.0` => `2.0.0-beta1` - `effectie-cats-effect` => `effectie-cats-effect3`
  * Remove `effectie-scalaz-effect`
  * Scala `3.1.0` => `3.1.2`
  * Remove `can-equal`
  * `refined` `0.9.25` => `0.9.29`
  * `cats` `2.6.1` => `2.7.0`
  * `cats-effect` `2.5.4` => `3.3.12`
  * `extras` `0.1.0` => `0.15.0`
  * Add `just-semver` `0.5.0`
  * Add `extras-scala-io` `0.15.0`
* List JDK paths from Coursier (`cs java --installed`) (#166)
* Symlink to JDKs from Coursier (`cs java --installed`) (#167)
