### PR TITLE
jdk-sym-link v0.9.1

### DIFF
--- a/.scripts/install-jvm.sh
+++ b/.scripts/install-jvm.sh
@@ -5,7 +5,7 @@ set -eu
 app_original_executable_name=jdk-sym-link
 app_executable_name=jdkslink
 app_name=jdk-sym-link-cli
-app_version=${1:-0.9.0}
+app_version=${1:-0.9.1}
 versioned_app_name="${app_name}-${app_version}"
 app_zip_file="${versioned_app_name}.zip"
 download_url="https://github.com/Kevin-Lee/jdk-sym-link/releases/download/v${app_version}/${app_zip_file}"

--- a/.scripts/install.sh
+++ b/.scripts/install.sh
@@ -5,7 +5,7 @@ set -eu
 app_original_executable_name=jdk-sym-link
 app_executable_name=jdkslink
 app_name=jdk-sym-link-cli
-app_version=${1:-0.9.0}
+app_version=${1:-0.9.1}
 app_package_file="${app_name}"
 download_url="https://github.com/Kevin-Lee/jdk-sym-link/releases/download/v${app_version}/${app_package_file}"
 

--- a/changelogs/0.9.1.md
+++ b/changelogs/0.9.1.md
@@ -1,0 +1,8 @@
+## [0.9.1](https://github.com/Kevin-Lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone13) - 2022-06-14
+
+## Fix
+* Error when JDK version is neither `SemVer` nor decimal version (#174)
+
+## Done
+* Add PR labeler (#175)
+* Add `dependabot` for GitHub Actions (#177)

--- a/project/SbtProjectInfo.scala
+++ b/project/SbtProjectInfo.scala
@@ -1,6 +1,6 @@
 object SbtProjectInfo {
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "0.9.0"
+  val ProjectVersion: String = "0.9.1"
 
 }


### PR DESCRIPTION
# jdk-sym-link v0.9.1
## [0.9.1](https://github.com/Kevin-Lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone13) - 2022-06-14

## Fix
* Error when JDK version is neither `SemVer` nor decimal version (#174)

## Done
* Add PR labeler (#175)
* Add `dependabot` for GitHub Actions (#177)
