### PR TITLE
jdk-sym-link v0.10.0

### DIFF
--- a/changelogs/0.10.0.md
+++ b/changelogs/0.10.0.md
@@ -1,0 +1,8 @@
+## [0.10.0](https://github.com/kevin-lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone14) - 2023-10-14
+
+## New Feature
+* Support [SdkMan!](https://sdkman.io) (#332)
+
+## Internal Housekeeping
+* Bump effectie to `2.0.0-beta2` (#211)
+  * Bump to `2.0.0-beta13`


### PR DESCRIPTION
# jdk-sym-link v0.10.0
## [0.10.0](https://github.com/kevin-lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone14) - 2023-10-14

## New Feature
* Support [SdkMan!](https://sdkman.io) (#332)

## Internal Housekeeping
* Bump effectie to `2.0.0-beta2` (#211)
  * Bump to `2.0.0-beta13`
