### PR TITLE
Fix #336 - Native image is using the HOME of build environment instead of the running environment's

### DIFF
--- a/modules/jdk-sym-link-core/src/main/scala/jdksymlink/core/data.scala
+++ b/modules/jdk-sym-link-core/src/main/scala/jdksymlink/core/data.scala
@@ -64,9 +64,11 @@ object data {
   }
 
   object SdkMan {
+    /* Do not change it to val. If it's val, the native build gets the HOME of the build environment. */
     def homeDir: String = sys.env("HOME")
 
-    val JavaBaseDirPath: JvmBaseDirPath = JvmBaseDirPath(s"$homeDir/.sdkman/candidates/java")
+    /* Do not change it to val. If it's val, the native build uses the HOME of the build environment. */
+    lazy val JavaBaseDirPath: JvmBaseDirPath = JvmBaseDirPath(s"$homeDir/.sdkman/candidates/java")
     lazy val javaBaseDirFile: File      = new File(JavaBaseDirPath.value)
 
     val SdkManJdkPattern = """([\w]+)(?:\.([\w]+))?(?:\.([\w]+))?(?:\.([\w]+))?-([\w]+)""".r


### PR DESCRIPTION
Fix #336 - Native image is using the HOME of build environment instead of the running environment's