### PR TITLE
jdk-sym-link v0.10.1

### DIFF
--- a/.scripts/install-jvm.sh
+++ b/.scripts/install-jvm.sh
@@ -5,7 +5,7 @@ set -eu
 app_original_executable_name=jdk-sym-link
 app_executable_name=jdkslink
 app_name=jdk-sym-link-cli
-app_version=${1:-0.10.0}
+app_version=${1:-0.10.1}
 versioned_app_name="${app_name}-${app_version}"
 app_zip_file="${versioned_app_name}.zip"
 download_url="https://github.com/kevin-lee/jdk-sym-link/releases/download/v${app_version}/${app_zip_file}"

--- a/.scripts/install.sh
+++ b/.scripts/install.sh
@@ -5,7 +5,7 @@ set -eu
 app_original_executable_name=jdk-sym-link
 app_executable_name=jdkslink
 app_name=jdk-sym-link-cli
-app_version=${1:-0.10.0}
+app_version=${1:-0.10.1}
 app_package_file="${app_name}"
 download_url="https://github.com/kevin-lee/jdk-sym-link/releases/download/v${app_version}/${app_package_file}"
 

--- a/changelogs/0.10.1.md
+++ b/changelogs/0.10.1.md
@@ -1,0 +1,4 @@
+## [0.10.1](https://github.com/kevin-lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone15) - 2023-10-15
+
+## Bug Fix
+* Fix: Native image is using the HOME of build environment instead of the running environment's (#336)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.10.0"
+ThisBuild / version := "0.10.1"


### PR DESCRIPTION
# jdk-sym-link v0.10.1
## [0.10.1](https://github.com/kevin-lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone15) - 2023-10-15

## Bug Fix
* Fix: Native image is using the HOME of build environment instead of the running environment's (#336)
