### PR TITLE
jdk-sym-link v1.0.0

### DIFF
--- a/.scripts/install-jvm.sh
+++ b/.scripts/install-jvm.sh
@@ -5,7 +5,7 @@ set -eu
 app_original_executable_name=jdk-sym-link
 app_executable_name=jdkslink
 app_name=jdk-sym-link-cli
-app_version=${1:-0.10.1}
+app_version=${1:-1.0.0}
 versioned_app_name="${app_name}-${app_version}"
 app_zip_file="${versioned_app_name}.zip"
 download_url="https://github.com/kevin-lee/jdk-sym-link/releases/download/v${app_version}/${app_zip_file}"

--- a/.scripts/install.sh
+++ b/.scripts/install.sh
@@ -5,7 +5,7 @@ set -eu
 app_original_executable_name=jdk-sym-link
 app_executable_name=jdkslink
 app_name=jdk-sym-link-cli
-app_version=${1:-0.10.1}
+app_version=${1:-1.0.0}
 app_package_file="${app_name}"
 download_url="https://github.com/kevin-lee/jdk-sym-link/releases/download/v${app_version}/${app_package_file}"
 

--- a/changelogs/1.0.0.md
+++ b/changelogs/1.0.0.md
@@ -1,0 +1,4 @@
+## [1.0.0](https://github.com/kevin-lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone16) - 2023-10-15
+
+## Breaking Change
+* Drop Coursier support (#333)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.10.1"
+ThisBuild / version := "1.0.0"


### PR DESCRIPTION
# jdk-sym-link v1.0.0
## [1.0.0](https://github.com/kevin-lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone16) - 2023-10-15

## Breaking Change
* Drop Coursier support (#333)
