### PR TITLE
jdk-sym-link v1.1.0

### DIFF
--- a/changelogs/1.1.0.md
+++ b/changelogs/1.1.0.md
@@ -1,0 +1,5 @@
+## [1.1.0](https://github.com/kevin-lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone17) - 2023-12-31
+
+## Internal Changes
+* Add `refined4s` as a dependency library (#351)
+* Replace custom newtypes (`opaque type`s) with `refined4s` (#353)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.0.0"
+ThisBuild / version := "1.1.0"


### PR DESCRIPTION
# jdk-sym-link v1.1.0
## [1.1.0](https://github.com/kevin-lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone17) - 2023-12-31

## Internal Changes
* Add `refined4s` as a dependency library (#351)
* Replace custom newtypes (`opaque type`s) with `refined4s` (#353)
