### PR TITLE
Close #379 - Bump Scala to 3.4.0 - update GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 env:
   GH_JAVA_VERSION: "17"
   GH_JVM_OPTS: "-Xss64m -Xms1024m -XX:MaxMetaspaceSize=1G -Xmx2G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
-  CLI_SCALA_BINARY_VERSION: "3.3.3"
+  CLI_SCALA_BINARY_VERSION: "3.4.0"
   GRAALVM_BIN_DIR_NAME: "native-image"
 
 jobs:

--- a/.github/workflows/m-upload-graalvm-to-gh-release.yml
+++ b/.github/workflows/m-upload-graalvm-to-gh-release.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   GH_JAVA_VERSION: "17"
-  CLI_SCALA_BINARY_VERSION: "3.3.3"
+  CLI_SCALA_BINARY_VERSION: "3.4.0"
   GRAALVM_BIN_DIR_NAME: "native-image"
 
 jobs:


### PR DESCRIPTION
Close #379 - Bump Scala to 3.4.0 - update GitHub Actions