### PR TITLE
jdk-sym-link v1.2.0

### DIFF
--- a/changelogs/1.2.0.md
+++ b/changelogs/1.2.0.md
@@ -1,0 +1,6 @@
+## [1.2.0](https://github.com/kevin-lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone18) - 2024-10-14
+
+## Internal Changes
+* GitHub Actions: Add builds with `macos-13 and` `macos-14` (Apple Silicon) (#417)
+* Bump Scala to `3.3.4` (#379)
+* Use `refined4s-extras-render` (#362)


### PR DESCRIPTION
# jdk-sym-link v1.2.0
## [1.2.0](https://github.com/kevin-lee/jdk-sym-link/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone18) - 2024-10-14

## Internal Changes
* GitHub Actions: Add builds with `macos-13 and` `macos-14` (Apple Silicon) (#417)
* Bump Scala to `3.3.4` (#379)
* Use `refined4s-extras-render` (#362)
