### PR TITLE
jdk-sym-link v1.3.0

### DIFF
--- a/.scripts/install-jvm.sh
+++ b/.scripts/install-jvm.sh
@@ -5,7 +5,7 @@ set -eu
 app_original_executable_name=jdk-sym-link
 app_executable_name=jdkslink
 app_name=jdk-sym-link-cli
-app_version=${1:-1.2.0}
+app_version=${1:-1.3.0}
 versioned_app_name="${app_name}-${app_version}"
 app_zip_file="${versioned_app_name}.zip"
 download_url="https://github.com/kevin-lee/jdk-sym-link/releases/download/v${app_version}/${app_zip_file}"

--- a/.scripts/install.sh
+++ b/.scripts/install.sh
@@ -28,7 +28,7 @@ case "$major_version" in
     if [ "$arch" == "x86_64" ]; then
       app_bin_suffix="macos-13"
     elif [ "$arch" == "arm64" ]; then
-      app_bin_suffix="macos-14-arm64"
+      app_bin_suffix="macos-${major_version}-arm64"
     else
       app_bin_suffix="macos-13"
     fi
@@ -42,7 +42,7 @@ esac
 app_original_executable_name=jdk-sym-link
 app_executable_name=jdkslink
 app_name=jdk-sym-link-cli
-app_version=${1:-1.2.0}
+app_version=${1:-1.3.0}
 app_package_file="${app_name}"
 download_url="https://github.com/kevin-lee/jdk-sym-link/releases/download/v${app_version}/${app_package_file}-${app_bin_suffix}"
 

--- a/changelogs/1.3.0.md
+++ b/changelogs/1.3.0.md
@@ -1,0 +1,9 @@
+## [1.3.0](https://github.com/kevin-lee/jdk-sym-link/issues?q=is%3Aissue+is%3Aclosed+milestone%3Amilestone19) - 2024-12-22
+
+## Internal Housekeeping
+* Drop supporting macOS 12 and add a new native version works built for macOS 15
+  
+  So it supports the following macOS versions:
+  * macOS 13 (Intel)
+  * macOS 14 (Apple Silicon)
+  * macOS 15 (Apple Silicon)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.2.0"
+ThisBuild / version := "1.3.0"


### PR DESCRIPTION
# jdk-sym-link v1.3.0
## [1.3.0](https://github.com/kevin-lee/jdk-sym-link/issues?q=is%3Aissue+is%3Aclosed+milestone%3Amilestone19) - 2024-12-22

## Internal Housekeeping
* Drop supporting macOS 12 and add a new native version works built for macOS 15
  
  So it supports the following macOS versions:
  * macOS 13 (Intel)
  * macOS 14 (Apple Silicon)
  * macOS 15 (Apple Silicon)
