### PR TITLE
Update `.gitignore` to exclude .bloop and Metals configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ target/
 .idea_modules/
 bin/
 
+.bloop/
+project/**/metals.sbt
+
 .history
 .cache
 .lib/


### PR DESCRIPTION
Update `.gitignore` to exclude .bloop and Metals configuration files