### PR TITLE
Update GitHub Actions workflows: macOS versions in build and release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-13 ]
+        os: [ ubuntu-latest, macos-14 ]
         run-binary: [ jdk-sym-link-cli ]
 
     steps:
@@ -109,9 +109,9 @@ jobs:
       matrix:
         # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
         os:
-          - { name: "macOS 13",               value: "macos-13", bin-suffix: "macos-13" }
           - { name: "macOS 14 Apple Silicon", value: "macos-14", bin-suffix: "macos-14-arm64" }
           - { name: "macOS 15 Apple Silicon", value: "macos-15", bin-suffix: "macos-15-arm64" }
+          - { name: "macOS 26 Apple Silicon", value: "macos-26", bin-suffix: "macos-26-arm64" }
         run-binary: [ jdk-sym-link-cli ]
     steps:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,9 +76,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - { name: "macOS 13",               value: "macos-13", bin-suffix: "macos-13" }
           - { name: "macOS 14 Apple Silicon", value: "macos-14", bin-suffix: "macos-14-arm64" }
           - { name: "macOS 15 Apple Silicon", value: "macos-15", bin-suffix: "macos-15-arm64" }
+          - { name: "macOS 26 Apple Silicon", value: "macos-26", bin-suffix: "macos-26-arm64" }
         run-binary: [ jdk-sym-link-cli ]
     steps:
 


### PR DESCRIPTION
## Update GitHub Actions workflows: macOS versions in build and release workflows

- Remove macOS 13 as it was retired.
- Add macOS 26 (arm64)