### PR TITLE
Replace `==` with `===` for strict equality checks and improve condition handling.

### DIFF
--- a/modules/jdk-sym-link-cli/src/main/scala/jdksymlink/cli/MainIo.scala
+++ b/modules/jdk-sym-link-cli/src/main/scala/jdksymlink/cli/MainIo.scala
@@ -16,14 +16,14 @@ abstract class MainIo[A](
   protected val name: String,
   protected val header: String,
   protected val helpFlag: Boolean = true,
-//  protected val helpFormat: HelpFormat = HelpFormat.autoColors(sys.env),
-  protected val helpFormat: HelpFormat =
-    if (sys.env.get("NO_COLOR").fold("")(_.trim) == "")
-      HelpFormat.Colors
-    else
-      HelpFormat.Plain,
   protected val version: String = ""
 ) extends IOApp {
+
+  //  val helpFormat: HelpFormat = HelpFormat.autoColors(sys.env)
+  val helpFormat: HelpFormat =
+    if sys.env.get("NO_COLOR").fold("")(_.trim).isEmpty
+    then HelpFormat.Colors
+    else HelpFormat.Plain
 
   def main: Opts[IO[ExitCode]]
 
@@ -53,8 +53,8 @@ object MainIo {
     for {
       parseResult <- effectOf(
                        command.parse(
-                         PlatformApp.ambientArgs getOrElse args,
-                         PlatformApp.ambientEnvs getOrElse sys.env
+                         PlatformApp.ambientArgs.getOrElse(args),
+                         PlatformApp.ambientEnvs.getOrElse(sys.env)
                        )
                      )
       exitCode    <- parseResult.fold(printHelp[F](helpRender), identity)

--- a/modules/jdk-sym-link-core/src/main/scala/jdksymlink/core/data.scala
+++ b/modules/jdk-sym-link-core/src/main/scala/jdksymlink/core/data.scala
@@ -25,12 +25,12 @@ object data {
 
       def dirExist: Boolean = {
         import sys.process.*
-        List("[", "-d", path.value, "]").! == 0
+        List("[", "-d", path.value, "]").! === 0
       }
 
       def fileExist: Boolean = {
         import sys.process.*
-        List("[", "-f", path.value, "]").! == 0
+        List("[", "-f", path.value, "]").! === 0
       }
 
       def nonEmptyInside: Boolean = {
@@ -133,7 +133,7 @@ object data {
 
               case ((Some(major1), None), (Some(major2), Some(_))) =>
                 val m = major1.toInt.compareTo(major2.toInt)
-                if (m == 0)
+                if (m === 0)
                   -1
                 else
                   m
@@ -143,7 +143,7 @@ object data {
 
               case ((Some(major1), Some(_)), (Some(major2), None)) =>
                 val m = major1.toInt.compareTo(major2.toInt)
-                if (m == 0)
+                if (m === 0)
                   1
                 else
                   m

--- a/modules/jdk-sym-link-core/src/main/scala/jdksymlink/cs/CoursierCmd.scala
+++ b/modules/jdk-sym-link-core/src/main/scala/jdksymlink/cs/CoursierCmd.scala
@@ -110,15 +110,15 @@ object CoursierCmd {
       extension (version: Version) {
         def major: MajorVersion = version.value match {
           case SemVer(m, n, _, _, _) =>
-            MajorVersion(if (m.value == 1) n.value else m.value)
+            MajorVersion(if (m.value === 1) n.value else m.value)
 
           case DecVer(m, n, _, _) =>
-            MajorVersion(if (m.value == 1) n.value else m.value)
+            MajorVersion(if (m.value === 1) n.value else m.value)
 
           case DotSeparatedVersion(v, vs) =>
             val vNum = v.toInt
             MajorVersion(
-              if vNum == 1 then
+              if vNum === 1 then
                 vs.take(1)
                   .headOption
                   .filter(_.forall(_.isDigit))


### PR DESCRIPTION
Replace `==` with `===` for strict equality checks and improve condition handling.